### PR TITLE
pom.xml: fix antrun plugin build

### DIFF
--- a/studio-dist/pom.xml
+++ b/studio-dist/pom.xml
@@ -50,105 +50,107 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>install-studio</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <attach>false</attach>
-                            <outputDirectory>${top.level.basedir}
-                            </outputDirectory>
-                            <finalName>${final.name}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <descriptor>
-                                ${assembly.descriptor.dir}/assembly.xml
-                            </descriptor>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${top.level.basedir}</directory>
-                            <includes>
-                                <include>*.tar.gz</include>
-                                <include>${final.name}/**</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                        <fileset>
-                            <directory>${final.name}</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <echo file="${top.level.basedir}/dist.sh">
-                                    cd ${studio-ui.dir}
-                                    npm install &amp;&amp; npm run build || exit 1
-                                    rm -f ${top.level.basedir}/dist.sh
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.4</version>
+                    <executions>
+                        <execution>
+                            <id>install-studio</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                            <configuration>
+                                <attach>false</attach>
+                                <outputDirectory>${top.level.basedir}
+                                </outputDirectory>
+                                <finalName>${final.name}</finalName>
+                                <appendAssemblyId>false</appendAssemblyId>
+                                <descriptor>
+                                    ${assembly.descriptor.dir}/assembly.xml
+                                </descriptor>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <filesets>
+                            <fileset>
+                                <directory>${top.level.basedir}</directory>
+                                <includes>
+                                    <include>*.tar.gz</include>
+                                    <include>${final.name}/**</include>
+                                </includes>
+                                <followSymlinks>false</followSymlinks>
+                            </fileset>
+                            <fileset>
+                                <directory>${final.name}</directory>
+                            </fileset>
+                        </filesets>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <tasks>
+                                    <echo file="${top.level.basedir}/dist.sh">
+                                        cd ${studio-ui.dir}
+                                        npm install &amp;&amp; npm run build || exit 1
+                                        rm -f ${top.level.basedir}/dist.sh
 
-                                    rm -rf \
-                                    ${top.level.basedir}/${final.name}/ui/*
+                                        rm -rf \
+                                        ${top.level.basedir}/${final.name}/ui/*
 
-                                    cp -r \
-                                    ${top.level.basedir}/studio-ui/assets/images \
-                                    ${top.level.basedir}/studio-ui/dist
+                                        cp -r \
+                                        ${top.level.basedir}/studio-ui/assets/images \
+                                        ${top.level.basedir}/studio-ui/dist
 
-                                    cp -r \
-                                    ${top.level.basedir}/studio-ui/assets/vendors \
-                                    ${top.level.basedir}/studio-ui/dist
+                                        cp -r \
+                                        ${top.level.basedir}/studio-ui/assets/vendors \
+                                        ${top.level.basedir}/studio-ui/dist
 
-                                    cp -r \
-                                    ${top.level.basedir}/studio-ui/dist \
-                                    ${top.level.basedir}/${final.name}/ui
+                                        cp -r \
+                                        ${top.level.basedir}/studio-ui/dist \
+                                        ${top.level.basedir}/${final.name}/ui
 
-                                    echo
-                                    echo "Build studio ok."
-                                    echo
+                                        echo
+                                        echo "Build studio ok."
+                                        echo
 
-                                    cd ..
-                                    tar -zcvf \
-                                    ${top.level.basedir}/${final.name}.tar.gz \
-                                    ${final.name} || exit 1
-                                    rm -f ${top.level.basedir}/dist.sh
-                                    echo
-                                    echo "hugegraph-studio dist tar.gz available at:
-                                    ${top.level.basedir}/${final.name}.tar.gz"
-                                    echo
-                                </echo>
-                                <exec executable="${shell-executable}"
-                                      dir="${top.level.basedir}"
-                                      failonerror="true">
-                                    <arg line="./dist.sh"/>
-                                </exec>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+                                        cd ..
+                                        tar -zcvf \
+                                        ${top.level.basedir}/${final.name}.tar.gz \
+                                        ${final.name} || exit 1
+                                        rm -f ${top.level.basedir}/dist.sh
+                                        echo
+                                        echo "hugegraph-studio dist tar.gz available at:
+                                        ${top.level.basedir}/${final.name}.tar.gz"
+                                        echo
+                                    </echo>
+                                    <exec executable="${shell-executable}"
+                                          dir="${top.level.basedir}"
+                                          failonerror="true">
+                                        <arg line="./dist.sh"/>
+                                    </exec>
+                                </tasks>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
 </project>


### PR DESCRIPTION
Or else it will fail to build:
```
➜  hugegraph-studio git:(master) mvn package -DskipTests -e
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] hugegraph-studio                                                   [pom]
[INFO] studio-api                                                         [war]
[INFO] studio-dist                                                        [jar]
[INFO]
[INFO] ----------------< com.baidu.hugegraph:hugegraph-studio >----------------
[INFO] Building hugegraph-studio 0.9.0                                    [1/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] -------------------< com.baidu.hugegraph:studio-api >-------------------
[INFO] Building studio-api 0.9.0                                          [2/3]
[INFO] --------------------------------[ war ]---------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ studio-api ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 2 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ studio-api ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ studio-api ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/cholerae/Documents/javacode/hugegraph-studio/studio-api/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ studio-api ---
[INFO] No sources to compile
[INFO]
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ studio-api ---
[INFO] Tests are skipped.
[INFO]
[INFO] --- maven-war-plugin:2.1.1:war (default-war) @ studio-api ---
[INFO] Packaging webapp
[INFO] Assembling webapp [studio-api] in [/Users/cholerae/Documents/javacode/hugegraph-studio/studio-api/target/studio-api]
[INFO] Processing war project
[INFO] Copying webapp webResources [/Users/cholerae/Documents/javacode/hugegraph-studio/studio-api/src/main/webapp/WEB-INF] to [/Users/cholerae/Documents/javacode/hugegraph-studio/studio-api/target/studio-api]
[INFO] Copying webapp resources [/Users/cholerae/Documents/javacode/hugegraph-studio/studio-api/src/main/webapp]
[INFO] Webapp assembled in [358 msecs]
[INFO] Building war: /Users/cholerae/Documents/javacode/hugegraph-studio/studio-api/target/studio-api.war
[INFO] WEB-INF/web.xml already added, skipping
[INFO]
[INFO] ------------------< com.baidu.hugegraph:studio-dist >-------------------
[INFO] Building studio-dist 0.9.0                                         [3/3]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ studio-dist ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/cholerae/Documents/javacode/hugegraph-studio/studio-dist/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ studio-dist ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ studio-dist ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/cholerae/Documents/javacode/hugegraph-studio/studio-dist/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ studio-dist ---
[INFO] No sources to compile
[INFO]
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ studio-dist ---
[INFO] Tests are skipped.
[INFO]
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ studio-dist ---
[INFO]
[INFO] --- maven-assembly-plugin:2.4:single (install-studio) @ studio-dist ---
[INFO] Copying files to /Users/cholerae/Documents/javacode/hugegraph-studio/studio-dist/../hugegraph-studio-0.9.0
[INFO]
[INFO] --- maven-antrun-plugin:1.3:run (default) @ studio-dist ---
[INFO] Executing tasks
     [exec] env: node: No such file or directory
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for hugegraph-studio 0.9.0:
[INFO]
[INFO] hugegraph-studio ................................... SUCCESS [  0.011 s]
[INFO] studio-api ......................................... SUCCESS [  3.477 s]
[INFO] studio-dist ........................................ FAILURE [  2.464 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.173 s
[INFO] Finished at: 2019-06-19T20:56:05+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.3:run (default) on project studio-dist: An Ant BuildException has occured: exec returned: 1 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.3:run (default) on project studio-dist: An Ant BuildException has occured: exec returned: 1
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.MojoExecutionException: An Ant BuildException has occured: exec returned: 1
    at org.apache.maven.plugin.antrun.AbstractAntMojo.executeTasks (AbstractAntMojo.java:131)
    at org.apache.maven.plugin.antrun.AntRunMojo.execute (AntRunMojo.java:98)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.tools.ant.BuildException: exec returned: 1
    at org.apache.tools.ant.taskdefs.ExecTask.runExecute (ExecTask.java:636)
    at org.apache.tools.ant.taskdefs.ExecTask.runExec (ExecTask.java:662)
    at org.apache.tools.ant.taskdefs.ExecTask.execute (ExecTask.java:487)
    at org.apache.tools.ant.UnknownElement.execute (UnknownElement.java:288)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.apache.tools.ant.dispatch.DispatchUtils.execute (DispatchUtils.java:106)
    at org.apache.tools.ant.Task.perform (Task.java:348)
    at org.apache.tools.ant.Target.execute (Target.java:357)
    at org.apache.maven.plugin.antrun.AbstractAntMojo.executeTasks (AbstractAntMojo.java:118)
    at org.apache.maven.plugin.antrun.AntRunMojo.execute (AntRunMojo.java:98)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR]
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :studio-dist
```

Signed-off-by: Cholerae Hu <choleraehyq@gmail.com>